### PR TITLE
Adds ' as a special character to be escaped in variable names

### DIFF
--- a/R/dt2vw.R
+++ b/R/dt2vw.R
@@ -41,7 +41,7 @@ dt2vw <- function(data, fileName, namespaces = NULL, target, weight = NULL, tag 
     if (!is.numeric(data[[target]])) {
         if (is.logical(data[[target]]) |
             sum(levels(factor(data[[target]])) == levels(factor(c(0,1)))) == 2) {
-            data[[target]][data[[target]] == TRUE] <- 1
+            data[[target]][data[[target]] == TRUE]  <- 1
             data[[target]][data[[target]] == FALSE] <- -1
         }
     }
@@ -53,8 +53,10 @@ dt2vw <- function(data, fileName, namespaces = NULL, target, weight = NULL, tag 
     }
 
     ## parse variable names
-    specChar <- '\\(|\\)|\\||\\:'
-    specCharSpace <- '\\(|\\)|\\||\\:| '
+    specChar      <- "\\(|\\)|\\||\\:|'"
+    specCharSpace <- "\\(|\\)|\\||\\:| |'"
+    #specChar      <- "\\(|\\)|\\||\\:"
+    #specCharSpace <- "\\(|\\)|\\||\\:| "
 
     parsingNames <- function(x) {
         ret <- c()

--- a/R/dt2vw.R
+++ b/R/dt2vw.R
@@ -55,8 +55,6 @@ dt2vw <- function(data, fileName, namespaces = NULL, target, weight = NULL, tag 
     ## parse variable names
     specChar      <- "\\(|\\)|\\||\\:|'"
     specCharSpace <- "\\(|\\)|\\||\\:| |'"
-    #specChar      <- "\\(|\\)|\\||\\:"
-    #specCharSpace <- "\\(|\\)|\\||\\:| "
 
     parsingNames <- function(x) {
         ret <- c()


### PR DESCRIPTION
`'` (apostrophes) in variable names should be escaped. This case arises frequently when doing NLP with variable names representing words (ex: "manhattan's")

E.G:
The following code previously yielded an error
```{r}
dt <- data.table::data.table(mtcars)
names(dt)
data.table::setnames(x = dt, old = "drat", new = "d'rat")
dt2vw(data = dt, fileName = "test.vw", target = "mpg")
```
```
 Error in parse(text = formatDataVW) : <text>:1:40: unexpected symbol
1: sprintf2('%f |A cyl:%f disp:%f hp:%f d'rat
```
